### PR TITLE
Revamp counter handling: dont clear counter, but keep track of differ…

### DIFF
--- a/nRF5_SDK_16.0.0_98a08e2/examples/ble_central/ble_app_uart_c/main.c
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/ble_central/ble_app_uart_c/main.c
@@ -744,8 +744,10 @@ static void ts_evt_callback(const ts_evt_t* evt)
             if (m_gpio_trigger_enabled)
             {
                 uint32_t tick_target;
+                uint32_t timestamp;
 
-                tick_target = evt->params.triggered.tick_target + 2;
+                timestamp = ts_timestamp_get_ticks_u32();
+                tick_target = TIME_SYNC_TIMESTAMP_TO_TICK(timestamp) + 2;
 
                 uint32_t err_code = ts_set_trigger(tick_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
                 APP_ERROR_CHECK(err_code);

--- a/nRF5_SDK_16.0.0_98a08e2/examples/ble_central/ble_app_uart_c/main.c
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/ble_central/ble_app_uart_c/main.c
@@ -706,14 +706,14 @@ static void ts_gpio_trigger_enable(void)
         return;
     }
 
-    // Round up to nearest second to next 250 ms to start toggling.
+    // Round up to nearest second to next 1000 ms to start toggling.
     // If the receiver has received a valid sync packet within this time, the GPIO toggling polarity will be the same.
 
     time_now_ticks = ts_timestamp_get_ticks_u64();
     time_now_msec = TIME_SYNC_TIMESTAMP_TO_USEC(time_now_ticks) / 1000;
 
-    time_target = TIME_SYNC_MSEC_TO_TICK(time_now_msec) + (250 * 2);
-    time_target = (time_target / 250) * 250;
+    time_target = TIME_SYNC_MSEC_TO_TICK(time_now_msec) + (1000 * 2);
+    time_target = (time_target / 1000) * 1000;
 
     err_code = ts_set_trigger(time_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
     APP_ERROR_CHECK(err_code);
@@ -744,10 +744,8 @@ static void ts_evt_callback(const ts_evt_t* evt)
             if (m_gpio_trigger_enabled)
             {
                 uint32_t tick_target;
-                uint32_t timestamp;
 
-                timestamp = ts_timestamp_get_ticks_u32();
-                tick_target = TIME_SYNC_TIMESTAMP_TO_TICK(timestamp) + 2;
+                tick_target = evt->params.triggered.tick_target + 1;
 
                 uint32_t err_code = ts_set_trigger(tick_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
                 APP_ERROR_CHECK(err_code);

--- a/nRF5_SDK_16.0.0_98a08e2/examples/ble_peripheral/ble_app_uart/main.c
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/ble_peripheral/ble_app_uart/main.c
@@ -772,8 +772,10 @@ static void ts_evt_callback(const ts_evt_t* evt)
             if (m_gpio_trigger_enabled)
             {
                 uint32_t tick_target;
+                uint32_t timestamp;
 
-                tick_target = evt->params.triggered.tick_target + 2;
+                timestamp = ts_timestamp_get_ticks_u32();
+                tick_target = TIME_SYNC_TIMESTAMP_TO_TICK(timestamp) + 2;
 
                 uint32_t err_code = ts_set_trigger(tick_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
                 APP_ERROR_CHECK(err_code);

--- a/nRF5_SDK_16.0.0_98a08e2/examples/ble_peripheral/ble_app_uart/main.c
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/ble_peripheral/ble_app_uart/main.c
@@ -734,14 +734,14 @@ static void ts_gpio_trigger_enable(void)
         return;
     }
 
-    // Round up to nearest second to next 250 ms to start toggling.
+    // Round up to nearest second to next 1000 ms to start toggling.
     // If the receiver has received a valid sync packet within this time, the GPIO toggling polarity will be the same.
 
     time_now_ticks = ts_timestamp_get_ticks_u64();
     time_now_msec = TIME_SYNC_TIMESTAMP_TO_USEC(time_now_ticks) / 1000;
 
-    time_target = TIME_SYNC_MSEC_TO_TICK(time_now_msec) + (250 * 2);
-    time_target = (time_target / 250) * 250;
+    time_target = TIME_SYNC_MSEC_TO_TICK(time_now_msec) + (1000 * 2);
+    time_target = (time_target / 1000) * 1000;
 
     err_code = ts_set_trigger(time_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
     APP_ERROR_CHECK(err_code);
@@ -772,10 +772,8 @@ static void ts_evt_callback(const ts_evt_t* evt)
             if (m_gpio_trigger_enabled)
             {
                 uint32_t tick_target;
-                uint32_t timestamp;
 
-                timestamp = ts_timestamp_get_ticks_u32();
-                tick_target = TIME_SYNC_TIMESTAMP_TO_TICK(timestamp) + 2;
+                tick_target = evt->params.triggered.tick_target + 1;
 
                 uint32_t err_code = ts_set_trigger(tick_target, nrf_gpiote_task_addr_get(NRF_GPIOTE_TASKS_OUT_3));
                 APP_ERROR_CHECK(err_code);

--- a/nRF5_SDK_16.0.0_98a08e2/examples/common/time_sync.c
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/common/time_sync.c
@@ -43,6 +43,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "app_error.h"
 #include "app_util_platform.h"
@@ -819,7 +820,7 @@ static inline bool sync_timer_offset_compensate(sync_pkt_t * p_pkt)
     // NRF_LOG_INFO("timer_offset: %d (wrapped: %d)", timer_offset, wrapped);
     // NRF_LOG_INFO("Local: %lu, Remote: %lu", local_timer, peer_timer);
 
-    if (timer_offset == 0 || timer_offset == TIME_SYNC_TIMER_MAX_VAL)
+    if (abs(timer_offset) <= 2 || timer_offset == TIME_SYNC_TIMER_MAX_VAL)
     {
         // Already in sync
         nrf_atomic_u32_add(&m_used_packet_count, 1);

--- a/nRF5_SDK_16.0.0_98a08e2/examples/common/time_sync.h
+++ b/nRF5_SDK_16.0.0_98a08e2/examples/common/time_sync.h
@@ -187,7 +187,7 @@ uint32_t ts_tx_stop(void);
  *          Time in milliseconds = target_tick * 16000000 / (TIME_SYNC_TIMER_MAX_VAL * 1000)
  *
  * @note When @ref ts_timestamp_get_ticks_u64 or @ref ts_timestamp_get_ticks_u32 is used as a reference,
- *       use @ref TIME_SYNC_TIMESTAMP_TO_USEC to convert to time unit for this function.
+ *       use @ref TIME_SYNC_TIMESTAMP_TO_TICK to convert to time unit for this function.
  *
  * @note Time sync receivers will adjust their local time according to the timing transmitter.
  *       If a trigger is set before a receiver is in sync with the transmitter, the local receiver timebase can skip ahead of the trigger time,


### PR DESCRIPTION
Changing the counter handling. No longer resetting counter, but keeping track of difference between transmitter and receivers counters. This avoids certain corner cases